### PR TITLE
Bugfix FXIOS-13877 [ToU Accessibility] Bottom sheet's description tex…

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -253,7 +253,9 @@ final class TermsOfUseViewController: UIViewController,
         let attributed = NSMutableAttributedString(
             string: TermsOfUseStrings.termsOfUseInfoText,
             attributes: [
-                .font: UX.descriptionFont,
+                // UITextView.attributedText overrides adjustsFontForContentSizeCategory behavior
+                // Unlike UILabel, we must explicitly set scaledFont() in the attributed string
+                .font: FXFontStyles.Regular.body.scaledFont(),
                 .foregroundColor: currentTheme().colors.textSecondary,
                 .paragraphStyle: paragraphStyle
             ]
@@ -285,6 +287,7 @@ final class TermsOfUseViewController: UIViewController,
         // This prevents dismissing the Terms of Use sheet when interacting with its content.
         if !sheetContainer.frame.contains(sender.location(in: view)) {
             store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .gestureDismiss))
+            coordinator?.dismissTermsFlow()
         }
     }
 
@@ -315,10 +318,12 @@ final class TermsOfUseViewController: UIViewController,
 
     @objc private func acceptTapped() {
         store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .termsAccepted))
+        coordinator?.dismissTermsFlow()
     }
 
     @objc private func remindMeLaterTapped() {
         store.dispatchLegacy(TermsOfUseAction(windowUUID: windowUUID, actionType: .remindMeLaterTapped))
+        coordinator?.dismissTermsFlow()
     }
 
     func applyTheme() {


### PR DESCRIPTION
…t is too small with iOS larger text setting

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

